### PR TITLE
Click on marker and see marker title on infowindow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 #hexo-tag-googlemaps
 
-Version: 1.0.0
+Version: 1.1.0
 
 Compatible with Hexo Version 3
 
@@ -30,7 +30,7 @@ Title, Latitude, Longitude, Icon
 * Icon (optional): a url of a marker icon. This can be relative to a icon in the hexo install or locaded elsewhere on a cdn.
 This replaces the usual icon ![http://i.imgur.com/ljtDDxV.png](http://i.imgur.com/ljtDDxV.png)
 
-If you're looking for a lot of icons, try this place: [https://code.google.com/p/google-maps-icons](https://code.google.com/p/google-maps-icons)
+If you're looking for a lot of icons, try this place: [github.com/giangoulas/google-maps-icons](https://github.com/giangoulas/google-maps-icons/tree/d0da0fb6974bec62b7f8d0e0f96ca90dd5371767/wiki)
 
 ##Simple Example
 

--- a/google-maps-template.html
+++ b/google-maps-template.html
@@ -26,8 +26,16 @@
         'zIndex' : <%- i %>,
         'icon': '<%- marker.icon %>'
       };
-     
-      var marker<%- i %> = new window.google.maps.Marker(opts<%- i %>);
+
+     var infowindow<%- i %> = new window.google.maps.InfoWindow({
+       content: '<%- marker.name %>'
+     });
+
+     var marker<%- i %> = new window.google.maps.Marker(opts<%- i %>);
+
+     marker<%- i %>.addListener('click', function(){
+       infowindow<%- i %>.open(map, marker<%- i %>)
+     })
    <%}) %>
 
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexo-tag-googlemaps",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "main": "index",
   "author": {
     "name": "Jesse Harlin",
@@ -8,8 +8,8 @@
     "url": "http://jesseharlin.net/"
   },
   "repository": {
-	"type": "git",
-	"url": "git@github.com:the-simian/hexo-tag-googlemaps.git"
+    "type": "git",
+    "url": "git@github.com:the-simian/hexo-tag-googlemaps.git"
   },
   "dependencies": {
     "lodash": "^2.4.1"


### PR DESCRIPTION
Currently the title is used as a title attribute (only visible on sustained hover), with this change you can click on the marker and see an [infowindow](https://developers.google.com/maps/documentation/javascript/examples/infowindow-simple)

Also README updated with new place to look for icons (old one down)

Cheers!