### PR TITLE
Fixed usage of _.template()

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ function googleMaps(args, content) {
   };
 
 
-  var templateFunction = _.template(template)
+  var templateFunction = _.template(template);
   var compiledMap = templateFunction(model);
 
   //  console.log(compiledMap);

--- a/index.js
+++ b/index.js
@@ -38,9 +38,10 @@ function googleMaps(args, content) {
     markers: markers,
     apikey: APIKey
   };
-  
 
-  var compiledMap = _.template(template, model);
+
+  var templateFunction = _.template(template)
+  var compiledMap = templateFunction(model);
 
   //  console.log(compiledMap);
   // console.log('\n\n\n', args, content);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexo-tag-googlemaps",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "main": "index",
   "author": {
     "name": "Jesse Harlin",


### PR DESCRIPTION
Fixed usage of template function from lodash 2 to lodash 4 because the original code did not work.

https://lodash.com/docs/2.4.2#template

> Returns a compiled function when no data object is given, else it returns the interpolated text.

Until lodash 2, passing data to the second argument returned the compiled string.

https://lodash.com/docs/4.17.4#template

> Returns the compiled template function.

In lodash 4, compiled template functions are returned regardless of arguments.